### PR TITLE
transition period: all coords will be removed from playerfiles automa…

### DIFF
--- a/src/thederpgamer/edencore/EdenCore.java
+++ b/src/thederpgamer/edencore/EdenCore.java
@@ -39,6 +39,7 @@ import thederpgamer.edencore.element.ElementManager;
 import thederpgamer.edencore.element.items.PrizeBars;
 import thederpgamer.edencore.gui.exchangemenu.ExchangeMenuControlManager;
 import thederpgamer.edencore.manager.*;
+import thederpgamer.edencore.navigation.NavigationUtilManager;
 import thederpgamer.edencore.network.client.ExchangeItemCreatePacket;
 import thederpgamer.edencore.network.client.ExchangeItemRemovePacket;
 import thederpgamer.edencore.network.client.RequestSpawnEntryPacket;

--- a/src/thederpgamer/edencore/commands/NavigationAdminCommand.java
+++ b/src/thederpgamer/edencore/commands/NavigationAdminCommand.java
@@ -6,8 +6,8 @@ import api.utils.game.chat.CommandInterface;
 import org.schema.common.util.linAlg.Vector3i;
 import org.schema.game.common.data.player.PlayerState;
 import org.schema.game.common.data.player.SavedCoordinate;
+import thederpgamer.edencore.navigation.NavigationUtilManager;
 import thederpgamer.edencore.utils.PlayerDataUtil;
-import thederpgamer.edencore.manager.NavigationUtilManager;
 
 import javax.annotation.Nullable;
 import java.sql.SQLException;
@@ -94,7 +94,9 @@ public class NavigationAdminCommand implements CommandInterface {
                 }
                 return true;
             }
-            case "insert": {
+            case "killcontainer": {
+                NavigationUtilManager.instance.removeOldSaveContainer();
+                PlayerUtils.sendMessage(admin,"removed data container");
                 return true;
             }
         }

--- a/src/thederpgamer/edencore/data/other/NavigationListContainer.java
+++ b/src/thederpgamer/edencore/data/other/NavigationListContainer.java
@@ -39,7 +39,7 @@ public class NavigationListContainer implements Serializable {
         if (objs.size()==0) {
             NavigationListContainer c = new NavigationListContainer();
             //add to persisntence
-            PersistentObjectUtil.addObject(EdenCore.getInstance().getSkeleton(), c);
+        //    PersistentObjectUtil.addObject(EdenCore.getInstance().getSkeleton(), c);
             return c;
         }
         for (int i = objs.size()-1; i>0; i--) {

--- a/src/thederpgamer/edencore/navigation/NavigationUtilManager.java
+++ b/src/thederpgamer/edencore/navigation/NavigationUtilManager.java
@@ -1,6 +1,7 @@
 package thederpgamer.edencore.navigation;
 
 import api.mod.StarLoader;
+import api.mod.config.PersistentObjectUtil;
 import api.network.packets.PacketUtil;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.schema.common.util.linAlg.Vector3i;
@@ -9,6 +10,8 @@ import org.schema.game.server.controller.EntityNotFountException;
 import org.schema.game.server.data.GameServerState;
 import org.schema.schine.resource.tag.ListSpawnObjectCallback;
 import org.schema.schine.resource.tag.Tag;
+import thederpgamer.edencore.EdenCore;
+import thederpgamer.edencore.commands.NavigationAdminCommand;
 import thederpgamer.edencore.data.other.NavigationListContainer;
 import thederpgamer.edencore.utils.PlayerDataUtil;
 
@@ -64,7 +67,7 @@ public class NavigationUtilManager {
                 NavigationUtilManager.instance.updatePlayerCoordsInSaveFile(playerName, new HashMap<Long, SavedCoordinate>(),coordsRemoveList);
             }
             coordsRemoveList.clear(); //clears list, bc all players have been cleared.
-            saveListsPersistent();
+            //saveListsPersistent();
         } catch (SQLException throwables) {
             throwables.printStackTrace();
         }
@@ -73,7 +76,7 @@ public class NavigationUtilManager {
     public void addCoordinateToList(Vector3i sector, String name) {
         name = "[p]"+name;
         coordsAddList.put(sector.code(),new SavedCoordinate(sector,name, false));
-        saveListsPersistent();
+        //saveListsPersistent();
     }
 
     /**
@@ -87,14 +90,21 @@ public class NavigationUtilManager {
         coordsAddList.remove(sector.code());
         //save into remove list
         coordsRemoveList.add(sector.code());
-        saveListsPersistent();
+        //saveListsPersistent();
     }
 
     public void saveListsPersistent() {
         NavigationListContainer c = NavigationListContainer.getContainer();
         c.coordsAddList = this.coordsAddList;
         c.coordsRemoveList = this.coordsRemoveList;
+
         c.save();
+    }
+
+    public void removeOldSaveContainer() {
+        NavigationListContainer c = NavigationListContainer.getContainer();
+        PersistentObjectUtil.removeObject(EdenCore.getInstance().getSkeleton(),c);
+        PersistentObjectUtil.save(EdenCore.getInstance().getSkeleton());
     }
 
     public HashMap<Long, SavedCoordinate> getCoordsAddList() {
@@ -175,7 +185,7 @@ public class NavigationUtilManager {
             }
         });
 
-        mergeLists(newCoords,playersCoords);
+    //    mergeLists(newCoords,playersCoords);
         for (SavedCoordinate c: playersCoords) {
             if (blacklist.contains(c.getSector().code()))
                 playersCoords.remove(c);


### PR DESCRIPTION
…tically

This update will on serverupdate delete all public navigation markers that it had previously added to all playerfiles.
it also brings a command to permanently kill the persistent data container for the nav markers, to safely remove it from the save data

Tested on dedicated testrig

